### PR TITLE
Fix Nondeterministic Ordering in Tests Part 2

### DIFF
--- a/innodb-java-reader/src/test/java/com/alibaba/innodb/java/reader/AbstractTest.java
+++ b/innodb-java-reader/src/test/java/com/alibaba/innodb/java/reader/AbstractTest.java
@@ -15,6 +15,8 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.nio.ByteBuffer;
@@ -435,28 +437,49 @@ public class AbstractTest {
     };
   }
 
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface Ordinal {
+    int value();
+  }
+
   @Data
   public static class Employee {
+    @Ordinal(0)
     public final int id;
+    @Ordinal(1)
     public final long empno;
+    @Ordinal(2)
     public final String name;
+    @Ordinal(3)
     public final int deptno;
+    @Ordinal(4)
     public final String gender;
+    @Ordinal(5)
     public final String birthdate;
+    @Ordinal(6)
     public final String city;
+    @Ordinal(7)
     public final int salary;
+    @Ordinal(8)
     public final int age;
+    @Ordinal(9)
     public final String joindate;
+    @Ordinal(10)
     public final int level;
     @ToString.Exclude
+    @Ordinal(11)
     public final String profile;
+    @Ordinal(12)
     public final String address;
+    @Ordinal(13)
     public final String email;
   }
 
   @Data
   public static class Department {
+    @Ordinal(0)
     public final int deptno;
+    @Ordinal(1)
     public final String name;
   }
 

--- a/innodb-java-reader/src/test/java/com/alibaba/innodb/java/reader/AbstractTest.java
+++ b/innodb-java-reader/src/test/java/com/alibaba/innodb/java/reader/AbstractTest.java
@@ -523,16 +523,13 @@ public class AbstractTest {
   }
 
   protected static int getFieldOrdinal(Class<?> clazz, String fieldName) {
-    int ordinal = 0;
-    Field[] fields = clazz.getDeclaredFields();
-    for (Field field : fields) {
-      if (field.getName().equals(fieldName)) {
-        return ordinal;
-      }
-      ++ordinal;
+    try {
+      Field field = clazz.getDeclaredField(fieldName);
+      Ordinal order = field.getAnnotation(Ordinal.class);
+      return order.value();
+    } catch (NoSuchFieldException e) {
+      return -1;
     }
-
-    return -1;
   }
 
   protected static boolean hasSuperClass(Class<?> clazz) {


### PR DESCRIPTION
27 other tests from com.alibaba.innodb.java.reader.sk.SimpleSkTableReaderTest are flaky.

If java.lang.Object.getDeclaredFields() returns the fields in a different order multiple tests could fail. This PR ensures that the tests pass even if the order changes.

To guarantee the ordering of com.alibaba.innodb.java.reader.getFieldOrdinal(...), I've added annotations, PR: https://github.com/chrnndz3/innodb-java-reader/pull/1,  to Employee class and Department class to retrieve the field ordinal using the field annotations instead of iterating through getDeclaredField() which is nondeterministic.

As per https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--
