### PR TITLE
Fix Nondeterministic Ordering in Tests Part 1

### DIFF
--- a/innodb-java-reader/src/test/java/com/alibaba/innodb/java/reader/AbstractTest.java
+++ b/innodb-java-reader/src/test/java/com/alibaba/innodb/java/reader/AbstractTest.java
@@ -26,11 +26,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.zone.ZoneRules;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Properties;
-import java.util.TimeZone;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -487,6 +483,13 @@ public class AbstractTest {
     return TABLES.get(array, () -> {
       Class<?> clazz = array.getClass().getComponentType();
       Field[] fields = getInstanceFields(clazz);
+
+      Arrays.sort(fields, (o1, o2) -> {
+        Ordinal or1 = o1.getAnnotation(Ordinal.class);
+        Ordinal or2 = o2.getAnnotation(Ordinal.class);
+        return or1.value() - or2.value();
+      });
+
       List<Object[]> result = new ArrayList<>(array.length);
       for (int i = 0; i < array.length; i++) {
         Object[] temp = new Object[fields.length];

--- a/innodb-java-reader/src/test/java/com/alibaba/innodb/java/reader/AbstractTest.java
+++ b/innodb-java-reader/src/test/java/com/alibaba/innodb/java/reader/AbstractTest.java
@@ -26,7 +26,12 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.zone.ZoneRules;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+import java.util.TimeZone;
 import java.util.function.Consumer;
 import java.util.function.Function;
 

--- a/innodb-java-reader/src/test/java/com/alibaba/innodb/java/reader/AbstractTest.java
+++ b/innodb-java-reader/src/test/java/com/alibaba/innodb/java/reader/AbstractTest.java
@@ -15,6 +15,8 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.nio.ByteBuffer;
@@ -435,28 +437,49 @@ public class AbstractTest {
     };
   }
 
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface Ordinal {
+    int value();
+  }
+
   @Data
   public static class Employee {
+    @Ordinal(0)
     public final int id;
+    @Ordinal(1)
     public final long empno;
+    @Ordinal(2)
     public final String name;
+    @Ordinal(3)
     public final int deptno;
+    @Ordinal(4)
     public final String gender;
+    @Ordinal(5)
     public final String birthdate;
+    @Ordinal(6)
     public final String city;
+    @Ordinal(7)
     public final int salary;
+    @Ordinal(8)
     public final int age;
+    @Ordinal(9)
     public final String joindate;
+    @Ordinal(10)
     public final int level;
     @ToString.Exclude
+    @Ordinal(11)
     public final String profile;
+    @Ordinal(12)
     public final String address;
+    @Ordinal(13)
     public final String email;
   }
 
   @Data
   public static class Department {
+    @Ordinal(0)
     public final int deptno;
+    @Ordinal(1)
     public final String name;
   }
 


### PR DESCRIPTION
18 tests from com.alibaba.innodb.java.reader.sk.SimpleSkTableReaderTest are flaky.

If java.lang.Object.getDeclaredFields() returns the fields in a different order multiple tests could fail. This PR ensures that the tests pass even if the order changes.

To guarantee the ordering of com.alibaba.innodb.java.reader.getAllRows(...), I've added annotations, PR: https://github.com/alibaba/innodb-java-reader/pull/14,  to Employee class and Department class to sort the fields by their annotated values.

As per https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--
"The elements in the returned array are not sorted and are not in any particular order."