### PR TITLE
修复一些小 bug

### DIFF
--- a/innodb-java-reader/src/main/java/com/alibaba/innodb/java/reader/schema/TableDef.java
+++ b/innodb-java-reader/src/main/java/com/alibaba/innodb/java/reader/schema/TableDef.java
@@ -175,7 +175,7 @@ public class TableDef {
     if (column.isVariableLength()) {
       variableLengthColumnList.add(column);
       variableLengthColumnNum++;
-    } else if (CHAR.equals(column.getType()) && maxBytesPerChar > 1) {
+    } else if (CHAR.equals(column.getType()) && column.getMaxBytesPerChar() > 1) {
       // 多字符集则设置为varchar的读取方式
       column.setVarLenChar(true);
       variableLengthColumnList.add(column);

--- a/innodb-java-reader/src/main/java/com/alibaba/innodb/java/reader/schema/TableDefUtil.java
+++ b/innodb-java-reader/src/main/java/com/alibaba/innodb/java/reader/schema/TableDefUtil.java
@@ -132,6 +132,8 @@ public class TableDefUtil {
       }
       if (StringUtils.isNotEmpty(col.getColDataType().getCharacterSet())) {
         column.setCharset(col.getColDataType().getCharacterSet());
+      } else {
+        column.setCharset(tableDef.getDefaultCharset());
       }
       column.setNullable(true);
       if (col.getColumnSpecStrings() != null) {

--- a/innodb-java-reader/src/main/java/com/alibaba/innodb/java/reader/schema/TableDefUtil.java
+++ b/innodb-java-reader/src/main/java/com/alibaba/innodb/java/reader/schema/TableDefUtil.java
@@ -85,7 +85,7 @@ public class TableDefUtil {
         indexOfCollate = tableOptions.indexOf("collate");
       }
       if (indexOfCollate > 0) {
-        tableDef.setCollation((String) tableOptions.get(indexOfCollate + 1));
+        tableDef.setCollation((String) tableOptions.get(indexOfCollate + 2));
       }
     }
   }

--- a/innodb-java-reader/src/test/java/com/alibaba/innodb/java/reader/TableReaderFactoryTest.java
+++ b/innodb-java-reader/src/test/java/com/alibaba/innodb/java/reader/TableReaderFactoryTest.java
@@ -292,6 +292,13 @@ public class TableReaderFactoryTest extends AbstractTest {
   }
 
   @Test
+  public void testParseSqlWithCollate() {
+    String sql = "CREATE TABLE ttt(id int) DEFAULT CHARSET = utf8 COLLATE = utf8_bin";
+    TableDefProvider tableDefProvider = new SqlTableDefProvider(sql);
+    tableDefProvider.load();
+  }
+
+  @Test
   public void testTableDefProviderTableWithExactDataFilePath() {
     TableDefProvider tableDefProvider = new SqlFileTableDefProvider(
         "src/test/resources/test.sql");


### PR DESCRIPTION
修复了一些小问题

 - 解析到的 collate 是 `=` 的问题（偏移差 1）
 - 字段有单独声明的 charset 的时候，解析错误的问题（取错了参数，应该取字段的 MaxBytesPerChar 实际是用的表的）
 - 字段没声明 charset 但是表声明了 charset 的时候，字段长度计算错误的问题（需要使用默认 charset）

这些问题都来源于解析 MySQL 8 的 `mysql.user` 表，可以采取下面的办法去测试。

 - `show create table mysql.user` 然后复制 sql 改下表名创建一张新表
 - `insert into user1 select * from mysql.user` 将数据搬过去
 - `alter table user1 drop column User_attributes` json 字段还不支持，无法解析，先 drop 掉（这个 feature 我看下能不能搞的定，可以的话，我之后再 pr   https://github.com/alibaba/innodb-java-reader/issues/22）
 - 使用建表 sql 和数据文件进行测试