### PR TITLE
bug: fix character set and collate bug

### DIFF
--- a/innodb-java-reader/src/main/java/com/alibaba/innodb/java/reader/schema/TableDef.java
+++ b/innodb-java-reader/src/main/java/com/alibaba/innodb/java/reader/schema/TableDef.java
@@ -172,6 +172,10 @@ public class TableDef {
       nullableColumnList.add(column);
       nullableColumnNum++;
     }
+    if (column.getCharset() == null) {
+      column.setCharset(this.getDefaultCharset());
+      column.setCollation(this.getCollation());
+    }
     if (column.isVariableLength()) {
       variableLengthColumnList.add(column);
       variableLengthColumnNum++;

--- a/innodb-java-reader/src/main/java/com/alibaba/innodb/java/reader/schema/TableDef.java
+++ b/innodb-java-reader/src/main/java/com/alibaba/innodb/java/reader/schema/TableDef.java
@@ -179,7 +179,7 @@ public class TableDef {
     if (column.isVariableLength()) {
       variableLengthColumnList.add(column);
       variableLengthColumnNum++;
-    } else if (CHAR.equals(column.getType()) && maxBytesPerChar > 1) {
+    } else if (CHAR.equals(column.getType()) && column.getMaxBytesPerChar() > 1) {
       // 多字符集则设置为varchar的读取方式
       column.setVarLenChar(true);
       variableLengthColumnList.add(column);

--- a/innodb-java-reader/src/main/java/com/alibaba/innodb/java/reader/schema/TableDefUtil.java
+++ b/innodb-java-reader/src/main/java/com/alibaba/innodb/java/reader/schema/TableDefUtil.java
@@ -85,7 +85,12 @@ public class TableDefUtil {
         indexOfCollate = tableOptions.indexOf("collate");
       }
       if (indexOfCollate > 0) {
-        tableDef.setCollation((String) tableOptions.get(indexOfCollate + 1));
+        String collateNextOne = (String) tableOptions.get(indexOfCollate + 1);
+        if (!"=".equals(collateNextOne)) {
+          tableDef.setCollation(collateNextOne);
+        } else {
+          tableDef.setCollation((String) tableOptions.get(indexOfCollate + 2));
+        }
       }
     }
   }

--- a/innodb-java-reader/src/test/java/com/alibaba/innodb/java/reader/schema/TableDefUtilTest.java
+++ b/innodb-java-reader/src/test/java/com/alibaba/innodb/java/reader/schema/TableDefUtilTest.java
@@ -10,7 +10,6 @@ import org.junit.Test;
 import java.util.List;
 
 import static com.alibaba.innodb.java.reader.Constants.PRIMARY_KEY_NAME;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
@@ -94,7 +93,7 @@ public class TableDefUtilTest {
     assertThat(columnList.get(3).isNullable(), is(false));
     assertThat(columnList.get(3).getCharset(), is("utf8mb4"));
     assertThat(columnList.get(3).getJavaCharset(), is("UTF-8"));
-    assertThat(columnList.get(3).getCollation(), nullValue());
+    assertThat(columnList.get(3).getCollation(), is("utf8mb4_general_ci"));
     assertThat(columnList.get(3).isCollationCaseSensitive(), is(false));
 
     assertThat(columnList.get(4).getOrdinal(), is(4));
@@ -497,7 +496,7 @@ public class TableDefUtilTest {
     assertThat(columnList.get(0).isNullable(), is(true));
     assertThat(columnList.get(0).getCharset(), is("latin2"));
     assertThat(columnList.get(0).getJavaCharset(), is("ISO8859_2"));
-    assertThat(columnList.get(0).getCollation(), nullValue());
+    assertThat(columnList.get(0).getCollation(), is("latin2_bin"));
     // use table default collation
     assertThat(columnList.get(0).isCollationCaseSensitive(), is(true));
   }


### PR DESCRIPTION
This PR fixes three small bugs related to the character set and collate.

1. Both `COLLATE  collation_name` and `COLLATE = collation_name` are valid table option to set collate. Parsing the create table statement in the sql file only takes into account the case where there is no equal sign.

2. If neither `CHARACTER SET` nor `COLLATE` is specified for a column, the `CHARACTER SET` and `COLLATE` of the table should be used.

3. When determining whether a column is a variable-length char, the column's MaxBytesPerChar should be used instead of the table's MaxBytesPerChar.