### PR TITLE
Update testRangeQueryByPrimaryKeyNegative assertion logic

### DIFF
--- a/innodb-java-reader-cli/src/test/java/com/alibaba/innodb/java/reader/InnodbReaderBootstrapTest.java
+++ b/innodb-java-reader-cli/src/test/java/com/alibaba/innodb/java/reader/InnodbReaderBootstrapTest.java
@@ -269,7 +269,8 @@ public class InnodbReaderBootstrapTest {
   public void testRangeQueryByPrimaryKeyNegative() {
     String[] args = {"-ibd-file-path", sourceIbdFilePath, "-create-table-sql-file-path", createTableSqlPath,
         "-c", "range-query-by-pk", "-args", "700,800"};
-    InnodbReaderBootstrap.main(args);
+    boolean runnable = InnodbReaderBootstrap.run(args);
+    assertThat(runnable, is(false));
   }
 
   @Test


### PR DESCRIPTION
During the time I tried to examine the flakiness of the project, I noticed that testing behavior of `testRangeQueryByPrimaryKeyNegative` can be enhanced using existing functionalities.

I think even though the exceptions have been caught during invocation, we can use the return value to determine the correctness instead of simply calling the function. 

Would it be better to use some `enum` values to represent the status? Or examine the log file.
 