### PR TITLE
Update testRangeQueryByPrimaryKeyNegative assertion logic

### DIFF
--- a/innodb-java-reader-cli/src/test/java/com/alibaba/innodb/java/reader/InnodbReaderBootstrapTest.java
+++ b/innodb-java-reader-cli/src/test/java/com/alibaba/innodb/java/reader/InnodbReaderBootstrapTest.java
@@ -269,7 +269,8 @@ public class InnodbReaderBootstrapTest {
   public void testRangeQueryByPrimaryKeyNegative() {
     String[] args = {"-ibd-file-path", sourceIbdFilePath, "-create-table-sql-file-path", createTableSqlPath,
         "-c", "range-query-by-pk", "-args", "700,800"};
-    InnodbReaderBootstrap.main(args);
+    bool valid = InnodbReaderBootstrap.main(args);
+    assertThat(valid, is(false));
   }
 
   @Test


### PR DESCRIPTION
This commit updates the testing behavior of `com.alibaba.innodb.java.reader.InnodbReaderBootstrapTest.testRangeQueryByPrimaryKeyNegative`

I think the original test would not really guarantee anything. I changed the behavior so that it uses the return result of the setup function. In this way, the test is able to at least determine whether the program can run with the given arguments.

It tests for invalid input arguments and is supposed to throw an exception, which is caught during the program thus cannot be checked during test. I have two proposal for better testing behaviors.
1. One can conclude some enum values to describe successful or error status. 
2. The test can take advantage of the [log](https://github.com/shunfan-shao/innodb-java-reader/blob/master/innodb-java-reader-cli/src/main/java/com/alibaba/innodb/java/reader/cli/InnodbReaderBootstrap.java#L229) and maybe mock the log behavior and check the logs at the end. 


